### PR TITLE
Add notebooks on github.com without using raw (and unify http and https)

### DIFF
--- a/bookmarklet/nbviewer_bookmarklet.js
+++ b/bookmarklet/nbviewer_bookmarklet.js
@@ -5,15 +5,13 @@ url=null;
 gist = location.href.match(/^https?:\/\/gist\.github\.com\/(?:\w+\/)?([a-f0-9]+)$/);
 if (gist != null) {
 	url = url_root + gist[1];
-} 
+}
 else {
-	path = location.href.match(/^https:\/\/github\.com/);
-			
+	path = location.href.match(/^https:\/\/(github\.com\/.*\/)blob\/(.*\.ipynb)$/);
+	console.log(path);
 	if (path != null) {
-		path = location.href;
-		path = path.replace("/blob", "");
-		path = path.replace("https://", "urls/raw.");
-		url = url_root + path;
+		path = path[1] + path[2]; 
+		url = url_root + 'urls/raw.' + path;
 	}
 
 	else {
@@ -31,9 +29,9 @@ else {
 				url = url_root + 'url/' + path[1];
 			}
 		}
-
 	}
 }
 
 if (url) {
-void(window.open(url, 'nbviewer' + date.getTime()));}
+	void(window.open(url, 'nbviewer' + date.getTime()));
+}


### PR DESCRIPTION
I got frustrated having to click "Raw" on an `.ipynb` on GitHub, so fixed it.
In the process I unified the code for http and https, and got rid of the duplicate regex-es.
(Though having done that, I understood why they were there!)

The most important part is the GitHub part.
